### PR TITLE
fix: only add files ending with .plot to the queue

### DIFF
--- a/plotboss.mjs
+++ b/plotboss.mjs
@@ -91,7 +91,7 @@ function checkPlots() {
         return
       }
       // only consider finished plots
-      if (file.indexOf('.tmp') < 0) {
+      if (path.extname(file) == '.plot') {
         // check if plot is already being moved
         if (!queue.reduce((acc, curVal) => { return acc || (curVal [0] == dir && curVal[1] == file) }, false)) {
           log(c.bold.white(`** found new plot: ${file}, adding to queue **`))

--- a/plotboss.mjs
+++ b/plotboss.mjs
@@ -91,7 +91,7 @@ function checkPlots() {
         return
       }
       // only consider finished plots
-      if (path.extname(file) == '.plot') {
+      if (path.extname(file) === '.plot') {
         // check if plot is already being moved
         if (!queue.reduce((acc, curVal) => { return acc || (curVal [0] == dir && curVal[1] == file) }, false)) {
           log(c.bold.white(`** found new plot: ${file}, adding to queue **`))


### PR DESCRIPTION
Instead of adding everything except .tmp files, let's only add .plot files.

Using `rsync` for example, creates a temporary file name `.FILENAME.[a-zA-Z0-9{6}]` (probably not a valid regex..... 😂)